### PR TITLE
fix A problem The request Header incorrect frequently

### DIFF
--- a/src/main/java/it/pcan/test/feign/client/FeignSpringFormEncoder.java
+++ b/src/main/java/it/pcan/test/feign/client/FeignSpringFormEncoder.java
@@ -34,14 +34,10 @@ public class FeignSpringFormEncoder implements Encoder {
 
 
     private final List<HttpMessageConverter<?>> converters = new RestTemplate().getMessageConverters();
-    private final HttpHeaders multipartHeaders = new HttpHeaders();
-    private final HttpHeaders jsonHeaders = new HttpHeaders();
 
     public static final Charset UTF_8 = Charset.forName("UTF-8");
 
     public FeignSpringFormEncoder() {
-        multipartHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
-        jsonHeaders.setContentType(MediaType.APPLICATION_JSON);
     }
 
     /**
@@ -50,8 +46,12 @@ public class FeignSpringFormEncoder implements Encoder {
     @Override
     public void encode(Object object, Type bodyType, RequestTemplate template) throws EncodeException {
         if (isFormRequest(bodyType)) {
-            encodeMultipartFormRequest((Map<String, ?>) object, template);
+            final HttpHeaders multipartHeaders = new HttpHeaders();
+            multipartHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
+            encodeMultipartFormRequest((Map<String, ?>) object, multipartHeaders, template);
         } else {
+            final HttpHeaders jsonHeaders = new HttpHeaders();
+            jsonHeaders.setContentType(MediaType.APPLICATION_JSON);
             encodeRequest(object, jsonHeaders, template);
         }
     }
@@ -64,7 +64,7 @@ public class FeignSpringFormEncoder implements Encoder {
      * @param template
      * @throws EncodeException
      */
-    private void encodeMultipartFormRequest(Map<String, ?> formMap, RequestTemplate template) throws EncodeException {
+    private void encodeMultipartFormRequest(Map<String, ?> formMap, HttpHeaders multipartHeaders, RequestTemplate template) throws EncodeException {
         if (formMap == null) {
             throw new EncodeException("Cannot encode request with null form.");
         }


### PR DESCRIPTION
fix A problem The request Header incorrect frequently .
It often makes header is not correct.
When I use this project in my Project ,I found the server can not parse requestParameter. frequently.(but not every request, just frequently)
finally I found the reason is sometimes requestHeader is incorrect.  To be Specific, The value of "boundary" in requestHeader is different from body's boundary  sometimes that I found.
This often occurs, When I click different button quickly to quest different URL.
I think the Header should not be a global variable.
When I make the requestHeader be a local variable, It works fine. 
